### PR TITLE
Fix user primaryGroupID

### DIFF
--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -372,17 +372,17 @@ class ADExplorerSnapshot(object):
 
         domain = ADUtils.ldap2domain(distinguishedName)
 
-        pgID = {
+        membership_entry = {
             "attributes": {
-                "objectSid": entry['attributes']['objectSID'][0],
-                "primaryGroupID": entry['attributes']['primaryGroupID'][0]
+                "objectSid": ADUtils.get_entry_property(entry, 'objectSid'),
+                "primaryGroupID": ADUtils.get_entry_property(entry, 'primaryGroupID')
             }
         }
 
         user = {
             "AllowedToDelegate": [],
             "ObjectIdentifier": ADUtils.get_entry_property(entry, 'objectSid'),
-            "PrimaryGroupSid": MembershipEnumerator.get_primary_membership(pgID),
+            "PrimaryGroupSid": MembershipEnumerator.get_primary_membership(membership_entry),
             "Properties": {
                 "name": resolved_entry['principal'],
                 "domain": domain.upper(),

--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -372,10 +372,17 @@ class ADExplorerSnapshot(object):
 
         domain = ADUtils.ldap2domain(distinguishedName)
 
+        pgID = {
+            "attributes": {
+                "objectSid": entry['attributes']['objectSID'][0],
+                "primaryGroupID": entry['attributes']['primaryGroupID'][0]
+            }
+        }
+
         user = {
             "AllowedToDelegate": [],
             "ObjectIdentifier": ADUtils.get_entry_property(entry, 'objectSid'),
-            "PrimaryGroupSid": MembershipEnumerator.get_primary_membership(entry),
+            "PrimaryGroupSid": MembershipEnumerator.get_primary_membership(pgID),
             "Properties": {
                 "name": resolved_entry['principal'],
                 "domain": domain.upper(),


### PR DESCRIPTION
Fixes #6 

get_primary_membership from bloodhound.enumeration.memberships can't handle the list object returned from entry['attributes']['primary_membership'].

This PR allows the tool to return the correct primaryGroupID by defining a temporary dictionary that the get_primary_membership function can handle.