### PR TITLE
Fix: avoid sid=none in JSON output

### DIFF
--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -541,7 +541,8 @@ class ADExplorerSnapshot(object):
                     continue
                 try:
                     sid = self.computersidcache[target]
-                    user['AllowedToDelegate'].append(sid)
+                    if sid:
+                        user['AllowedToDelegate'].append(sid)
                 except KeyError:
                     if '.' in target:
                         user['AllowedToDelegate'].append(target.upper())

--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -404,7 +404,8 @@ class ADExplorerSnapshot(object):
                 continue
             try:
                 sid = self.computersidcache.get(target)
-                computer['AllowedToDelegate'].append(sid)
+                if sid:
+                    computer['AllowedToDelegate'].append(sid)
             except KeyError:
                 if '.' in target:
                     computer['AllowedToDelegate'].append(target.upper())


### PR DESCRIPTION
I had an issue with the output files. Bloodhound would fail when importing. The message in the dev console said something like `Cannot read property of null`.

I found that the `computers.json` contained lines like this:

```
       "AllowedToDelegate": [
            "S-1-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
             null
      ],
```

This patch makes sure to add sids to the `AllowedToDelegate` list only if they are not `Null` (or empty).

I reckon this happens when the SID is from another domain.