### PR TITLE
Fix AllowedToDelegate SID mapping freezing BloodHound imports

### DIFF
--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -403,7 +403,7 @@ class ADExplorerSnapshot(object):
                 logging.warning('Invalid delegation target: %s', host)
                 continue
             try:
-                sid = self.computersidcache.get(target)
+                sid = self.computersidcache[target]
                 computer['AllowedToDelegate'].append(sid)
             except KeyError:
                 if '.' in target:


### PR DESCRIPTION
Remediated #15 and #14 by changing line 406 from `sid = self.computersidcache.get(target)` to `sid = self.computersidcache[target]`. 

Similar to #12, I had issues with converted computer output data containing entries that caused BloodHound to throw errors and fail importing:
```json
"AllowedToDelegate": [
       null
],
```

**Detailed explanation:**
In Python, the `object.get(key)` method will return `null` if `key` is not found. In contrast, `object[key]` will throw a `KeyError` if `key` is not found. As the `AllowedToDelegate` mapping within ADExplorer relies on `self.computersidcache...` throwing a `KeyError` exception, the object must be reference using `self.computersidcache[key]`.


Pull request #12 technically patches this issue but leaves BloodHound data incomplete, causing mismatched `AllowedToDelegate` and `allowedtodelegate` entries. 


On a side note, ADExplorerSnapshot is an incredibly useful tool and I appreciate the effort put into creating it. 