### PR TITLE
Fixed TypeError in processDomains function

### DIFF
--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -297,10 +297,13 @@ class ADExplorerSnapshot(object):
 
     def processDomains(self):
         level_id = ADUtils.get_entry_property(self.domain_object, 'msds-behavior-version')
-        try:
-            functional_level = ADUtils.FUNCTIONAL_LEVELS[int(level_id)]
-        except KeyError:
-            functional_level = 'Unknown'
+        if level_id is None:
+            functional_level = 'Unkown'
+        else:
+            try:
+                functional_level = ADUtils.FUNCTIONAL_LEVELS[int(level_id)]
+            except KeyError:
+                functional_level = 'Unknown'
 
         domain = {
             "ObjectIdentifier": ADUtils.get_entry_property(self.domain_object, 'objectSid'),


### PR DESCRIPTION
Addressing a `TypeError` encountered in the processDomains function when `level_id` is `None`. 

This issue was leading to a failure in the execution of the script. 

I haven't investigated why `ADUtils.get_entry_property(self.domain_object, 'msds-behavior-version')`  returned a `None` type, but I suspect it's related to an issue with older domains (such as Windows 2000).