### PR TITLE
Create adidns_dump.py

### DIFF
--- a/scripts/adidns_dump.py
+++ b/scripts/adidns_dump.py
@@ -1,0 +1,39 @@
+from adexpsnapshot import ADExplorerSnapshot
+import pwnlib.term, pwnlib.log, logging
+from bloodhound.ad.utils import ADUtils
+from adidnsdump import dnsdump
+
+logging.basicConfig(handlers=[pwnlib.log.console])
+log = pwnlib.log.getLogger(__name__)
+log.setLevel(20)
+
+if pwnlib.term.can_init():
+    pwnlib.term.init()
+log.term_mode = pwnlib.term.term_mode
+
+import sys
+fh = open(sys.argv[1],"rb")
+
+ades = ADExplorerSnapshot(fh, '.', log)
+ades.preprocessCached()
+
+findDN = f',CN=MicrosoftDNS,CN=System,{ades.rootdomain}'.lower()
+
+print()
+
+for k,v in ades.dncache.items():
+    if k.lower().endswith(findDN):
+        entry = ades.snap.getObject(v)
+        for address in ADUtils.get_entry_property(entry, 'dnsRecord', [], raw=True):
+            dr = dnsdump.DNS_RECORD(address)
+            if dr['Type'] == 1:
+                address = dnsdump.DNS_RPC_RECORD_A(dr['Data'])
+                print("[+]","Type:",dnsdump.RECORD_TYPE_MAPPING[dr['Type']],"name:",k.split(',')[0].split('=')[1],"value:",address.formatCanonical())
+            if dr['Type'] in [a for a in dnsdump.RECORD_TYPE_MAPPING if dnsdump.RECORD_TYPE_MAPPING[a] in ['CNAME', 'NS', 'PTR']]:
+                address = dnsdump.DNS_RPC_RECORD_NODE_NAME(dr['Data'])
+                print("[+]","Type:",dnsdump.RECORD_TYPE_MAPPING[dr['Type']],"name:",k.split(',')[0].split('=')[1],"value:",address[list(address.fields)[0]].toFqdn())
+            elif dr['Type'] == 28:
+                address = dnsdump.DNS_RPC_RECORD_AAAA(dr['Data'])
+                print("[+]","Type:",dnsdump.RECORD_TYPE_MAPPING[dr['Type']],"name:",k.split(',')[0].split('=')[1],"value:",address.formatCanonical())
+            elif dr['Type'] not in [a for a in dnsdump.RECORD_TYPE_MAPPING if dnsdump.RECORD_TYPE_MAPPING[a] in ['A', 'AAAA,' 'CNAME', 'NS']]:
+                print("[+]","name:",k.split(',')[0].split('=')[1],'Unexpected record type seen: {}'.format(dr['Type']))


### PR DESCRIPTION
Code from adidnsdump
```
root@test:~/ADExplorerSnapshot.py/scripts# python3 adidns_dump.py ../tests/data/detectionlab.dat
[*] Server: dc.windomain.local
[*] Time of snapshot: 2021-12-01T05:48:42
[*] Mapping offset: 0x2a5637
[*] Object count: 3848
[+] Parsing properties: 1498
[+] Parsing classes: 269
[+] Parsing object offsets: 3848
[+] Restored pre-processed information from data cache

[+] Type: NS name: @ value: f.root-servers.net.
[+] Type: NS name: @ value: m.root-servers.net.
[+] Type: NS name: @ value: g.root-servers.net.
[+] Type: NS name: @ value: k.root-servers.net.
[+] Type: NS name: @ value: j.root-servers.net.
[+] Type: NS name: @ value: b.root-servers.net.
[+] Type: NS name: @ value: c.root-servers.net.
[+] Type: NS name: @ value: d.root-servers.net.
[+] Type: NS name: @ value: a.root-servers.net.
[+] Type: NS name: @ value: i.root-servers.net.
[+] Type: NS name: @ value: l.root-servers.net.
[+] Type: NS name: @ value: h.root-servers.net.
[+] Type: NS name: @ value: e.root-servers.net.
[+] Type: AAAA name: e.root-servers.net value: 2001:500:a8::e
[+] Type: AAAA name: h.root-servers.net value: 2001:500:1::53
[+] Type: AAAA name: l.root-servers.net value: 2001:500:9f::42
[+] Type: AAAA name: i.root-servers.net value: 2001:7fe::53
[+] Type: AAAA name: a.root-servers.net value: 2001:503:ba3e::2:30
[+] Type: AAAA name: d.root-servers.net value: 2001:500:2d::d
[+] Type: AAAA name: c.root-servers.net value: 2001:500:2::c
[+] Type: AAAA name: b.root-servers.net value: 2001:500:200::b
[+] Type: AAAA name: j.root-servers.net value: 2001:503:c27::2:30
[+] Type: AAAA name: k.root-servers.net value: 2001:7fd::1
[+] Type: AAAA name: g.root-servers.net value: 2001:500:12::d0d
[+] Type: AAAA name: m.root-servers.net value: 2001:dc3::35
[+] Type: AAAA name: f.root-servers.net value: 2001:500:2f::f

```