### PR TITLE
Allow other parsers

### DIFF
--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -1,4 +1,3 @@
-from adexpsnapshot.parser.classes import Snapshot
 from requests.structures import CaseInsensitiveDict
 
 import pwnlib.log, pwnlib.term, logging
@@ -30,10 +29,15 @@ from typing import List
 class ADExplorerSnapshot(object):
     OutputMode = Enum('OutputMode', ['BloodHound', 'Objects'])
 
-    def __init__(self, snapfile, outputfolder, log=None):
+    def __init__(self, snapfile, outputfolder, log=None, snapshot_parser=None):
         self.log = log
         self.output = outputfolder
-        self.snap = Snapshot(snapfile, log=log)
+
+        if not snapshot_parser:
+            from adexpsnapshot.parser.classes import Snapshot
+            snapshot_parser = Snapshot
+
+        self.snap = snapshot_parser(snapfile, log=log)
 
         self.snap.parseHeader()
 


### PR DESCRIPTION
Hi,

I forked ADExplorerSnapshot because much of the code is reusable to parse other files such as LDIF files, but replacing the parsing class is not straight forward. I use this fork as a dependency [here](https://github.com/SySS-Research/ldif2bloodhound). If you choose to merge this simple change, I could delete the fork and avoid useless redundancy.  Perhaps in the future even more file formats could be parsed and converted to BloodHound data, for example the ntds.dit.

What do you think?