### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+# Use Python 3.10 to avoid 3.11 incompatability
+# See https://github.com/ly4k/Certipy/issues/108
+ARG VERSION=3.10-alpine
+FROM python:$VERSION
+
+RUN <<-EOF
+    echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+    apk add git bash cmake build-base linux-headers python3-dev py3-capstone py3-psutil py3-unicorn@testing
+EOF
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT [ "python", "ADExplorerSnapshot.py" ]
+CMD [ "--help" ]


### PR DESCRIPTION
Added a Dockerfile to easy deployment.

This was helpful for me to avoid Python 3.11 incompatibilities on my host, due to https://github.com/ly4k/Certipy/issues/108.

Docker images can be built with a command like this: `docker build -t c3c/adexplorersnapshot .`

The resulting image can be used in a command like this: `docker run --rm -it -v "$(pwd):/src" c3c/adexplorersnapshot -o /src/out /src/adexplorer.dat`. That is the normal arguments go after the image name, as I made the script the entrypoint. Running the image with no arguments will default to showing the help.

`docker run --rm -it c3c/adexplorersnapshot`

```
usage: ADExplorerSnapshot.py [-h] [-o OUTPUT] [-m {BloodHound,Objects}] snapshot

AD Explorer snapshot ingestor for BloodHound

positional arguments:
  snapshot              Path to the snapshot .dat file.

options:
  -h, --help            show this help message and exit
  -o OUTPUT, --output OUTPUT
                        Path to the *.json output folder. Folder will be created if it doesn't exist. Defaults to the current directory.
  -m {BloodHound,Objects}, --mode {BloodHound,Objects}
                        The output mode to use. Besides BloodHound JSON output files, it is possible to dump all objects with all attributes to NDJSON. Defaults to BloodHound output mode.
```

