### PR TITLE
Fix for KeyError in trust resolution and TypeError in Bloodhound import

### DIFF
--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -664,7 +664,10 @@ class ADExplorerSnapshot(object):
             3: 'External',
             4: 'Unknown',
         }
-        trust['TrustType'] = trust_types[trust['TrustType']]
+
+        # checks to see if TrustType is already resolved
+        if(trust['TrustType'] not in trust_types.values()):
+            trust['TrustType'] = trust_types[trust['TrustType']]
         self.numTrusts += 1
         self.trusts.append(trust)
         return True

--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -363,6 +363,10 @@ class ADExplorerSnapshot(object):
                 'distinguishedname': distinguishedName
             },
             'LocalGroups': [],
+            'LocalAdmins': {'Collected': False, 'FailureReason': None, 'Results': []},
+            'RemoteDesktopUsers': {'Collected': False, 'FailureReason': None, 'Results': []},
+            'DcomUsers': {'Collected': False, 'FailureReason': None, 'Results': []},
+            'PSRemoteUsers': {'Collected': False, 'FailureReason': None, 'Results': []},
             'UserRights': [],
             'PrivilegedSessions': {
                 'Collected': False,

--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -659,7 +659,10 @@ class ADExplorerSnapshot(object):
             2: 'Outbound',
             3: 'Bidirectional',
         }
-        trust['TrustDirection'] = trust_directions[trust['TrustDirection']]
+
+        # checks to see if TrustDirection is already resolved
+        if(trust['TrustDirection'] not in trust_directions.values()):
+            trust['TrustDirection'] = trust_directions[trust['TrustDirection']]
 
         trust_types = {
             0: 'ParentChild',


### PR DESCRIPTION
Hey c3c, fantastic tool! I recently came across a couple of bugs when using this.

In processTrusts, the TrustDirection and TrustType properties were already resolved. This triggered KeyError exceptions. I've added checks to see if they've already been resolved.

The generated dataset also triggered exceptions (TypeError) when importing into BloodHound 4.3.1 as the ingestor was expecting various Results attributes.

Added some lines to ensure they exist in the resultant dataset.