### PR TITLE
Implement LDIF Output Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ In `BloodHound` output mode:
 
 In `Objects` output mode, all attributes for every object are parsed and outputted to NDJSON format.
 
+In `LDIF` output mode, all attributes for every object are parsed and outputted to LDIF format to be [parsed with BOFHound](https://github.com/coffeegist/bofhound/).
+
 ## Limitations
 
 The ingestor for BloodHound only supports offline information collection from the snapshot file and won't interact with systems on the network. That means features like session and localadmin collection are not available. GPO/OU collection is missing. The ingestor processes all data it possibly can from the snapshot (including ACLs), but will only output the JSON data that can be interpreted by BloodHound. You will only have the data available of the LDAP/DC that you ran the snapshot against.
@@ -37,9 +39,9 @@ pip3 install --user .
 ## Usage
 
 ```
-usage: ADExplorerSnapshot.py [-h] [-o OUTPUT] [-m {BloodHound,Objects}] snapshot
+usage: ADExplorerSnapshot.py [-h] [-o OUTPUT] [-m {BloodHound,Objects,LDIF}] snapshot
 
-ADExplorerSnapshot.py is an AD Explorer snapshot parser. It is made as an ingestor for BloodHound, and also supports full-object dumping to NDJSON.
+ADExplorerSnapshot.py is an AD Explorer snapshot parser. It is made as an ingestor for BloodHound, and also supports full-object dumping to NDJSON and LDIF.
 
 positional arguments:
   snapshot              Path to the snapshot .dat file.
@@ -49,9 +51,9 @@ optional arguments:
   -o OUTPUT, --output OUTPUT
                         Path to the *.json output folder. Folder will be created if it doesn't exist. 
                         Defaults to the current directory.
-  -m {BloodHound,Objects}, --mode {BloodHound,Objects}
+  -m {BloodHound,Objects,LDIF}, --mode {BloodHound,Objects,LDIF}
                         The output mode to use. Besides BloodHound JSON output files, it is possible
-                        to dump all objects with all attributes to NDJSON.
+                        to dump all objects with all attributes to NDJSON or LDIF formats.
                         Defaults to BloodHound output mode.
 ```
 

--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -27,7 +27,7 @@ from enum import Enum
 from typing import List
 
 class ADExplorerSnapshot(object):
-    OutputMode = Enum('OutputMode', ['BloodHound', 'Objects'])
+    OutputMode = Enum('OutputMode', ['BloodHound', 'Objects', 'LDIF'])
 
     def __init__(self, snapfile, outputfolder, log=None, snapshot_parser=None):
         self.log = log
@@ -102,6 +102,110 @@ class ADExplorerSnapshot(object):
             fh_out.close()
             result_q.task_done()
             
+        wq = queue.Queue()
+        results_worker = threading.Thread(target=write_worker, args=(wq, os.path.join(self.output, outputfile)))
+        results_worker.daemon = True
+        results_worker.start()
+
+        if self.log:
+            prog = self.log.progress("Collecting data", rate=0.1)
+
+        for idx, obj in enumerate(self.snap.objects):
+            wq.put((dict(obj.attributes.data)))
+
+            if self.log and self.log.term_mode:
+                prog.status(f"dumped {idx+1}/{self.snap.header.numObjects} objects")
+
+        if self.log:
+            prog.success(f"dumped {self.snap.header.numObjects} objects")
+
+        wq.put(None)
+        wq.join()
+
+        if self.log:
+            self.log.success(f"Output written to {outputfile}")
+
+    def outputLDIF(self):
+
+        import codecs, base64, datetime
+
+        outputfile = f"{self.snap.header.server}_{self.snap.header.filetimeUnix}_objects.ldif"
+
+        class LDIFEncoder:
+
+            timestamp_attributes = ['whenCreated', 'whenChanged', 'dSCorePropagationData' ]
+
+            def encode(self, obj):
+                if obj is None:
+                    return ""
+                elif isinstance(obj, dict):
+                    return self.encode_dict(obj)
+                elif isinstance(obj, list):
+                    return ", ".join(self.encode(item) for item in obj)
+                elif isinstance(obj, int):
+                    return str(obj if obj < 0x80000000 else obj - 0x100000000)
+                elif isinstance(obj, bytes):
+                    return base64.b64encode(obj).decode("ascii")
+                elif isinstance(obj, (str, float, bool)):
+                    return str(obj)
+                else:
+                    raise Exception(f"LDIFEncoder does not support objects of type {type(obj)}")
+
+            def encode_dict(self, obj):
+                lines = []
+                for key in sorted(obj.keys()):
+                    if key in LDIFEncoder.timestamp_attributes:
+                        encoded = self.encode_timestamp(obj[key], key)
+                    else:
+                        encoded = self.encode(obj[key])
+                    lines.append(f"{key}: {encoded}")
+                if len(lines):
+                    lines.append("")
+                return "\n".join(lines)
+
+            def encode_timestamp(self, value, attr=''):
+                try:
+                    if isinstance(value, list):
+                        if len(value) == 0:
+                            return "0"
+                        value = value[0]
+                    return datetime.datetime.fromtimestamp(value, datetime.UTC).strftime('%Y%m%d%H%M%S.0Z')
+                except:
+                    logging.warning(f"Failed to parse timestamp for attribute {attr}")
+                    return "0"
+
+        ldif_encoder = LDIFEncoder()
+
+        def write_worker(result_q, filename):
+            try:
+                fh_out = codecs.open(filename, 'w', 'utf-8')
+            except:
+                logging.warning('Could not write file: %s', filename)
+                result_q.task_done()
+                return
+
+            wroteOnce = False
+            while True:
+                data = result_q.get()
+
+                if data is None:
+                    break
+
+                if not wroteOnce:
+                    wroteOnce = True
+                else:
+                    fh_out.write('--------------------\n')
+
+                try:
+                    encoded_member = ldif_encoder.encode(data)
+                    fh_out.write(encoded_member)
+                except TypeError:
+                    logging.error('Data error {0}, could not convert data to LDIF'.format(repr(data)))
+                result_q.task_done()
+
+            fh_out.close()
+            result_q.task_done()
+
         wq = queue.Queue()
         results_worker = threading.Thread(target=write_worker, args=(wq, os.path.join(self.output, outputfile)))
         results_worker.daemon = True
@@ -1155,6 +1259,8 @@ def main():
         ades.outputBloodHound()
     if outputmode == ADExplorerSnapshot.OutputMode.Objects:
         ades.outputObjects()
+    if outputmode == ADExplorerSnapshot.OutputMode.LDIF:
+        ades.outputLDIF()
 
 if __name__ == '__main__':
     main()

--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -1227,7 +1227,7 @@ def main():
 
     parser.add_argument('snapshot', type=argparse.FileType('rb'), help="Path to the snapshot .dat file.")
     parser.add_argument('-o', '--output', required=False, type=pathlib.Path, help="Path to the *.json output folder. Folder will be created if it doesn't exist. Defaults to the current directory.", default=".")
-    parser.add_argument('-m', '--mode', required=False, help="The output mode to use. Besides BloodHound JSON output files, it is possible to dump all objects with all attributes to NDJSON. Defaults to BloodHound output mode.", choices=ADExplorerSnapshot.OutputMode.__members__, default='BloodHound')
+    parser.add_argument('-m', '--mode', required=False, help="The output mode to use. Besides BloodHound JSON output files, it is possible to dump all objects with all attributes to NDJSON or LDIF formats. Defaults to BloodHound output mode.", choices=ADExplorerSnapshot.OutputMode.__members__, default='BloodHound')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This pull request adds a new LDIF output mode which converts the AD snapshot into (mostly) equivalent ldapsearch output for further processing with the latest [BOFHound version](https://github.com/coffeegist/bofhound/pull/28).

The intention is to use LDIF as a common input source for BOFHound where all BloodHound related parsing improvements can be shared in a central place, independent of the tool used to gather the information (AD Explorer, ldapsearch BOF, pyldapsearch, ADWS, ...).

This should implement #23 and indirectly "fix" issues like #21, #52 and others.

For testing I did a `(objectGUID=*)` query over all relevant naming contexts:

```
LDAP_BASE="DC=ludus,DC=domain"

for dn in "$LDAP_BASE" "CN=Configuration,$LDAP_BASE" "CN=Schema,CN=Configuration,$LDAP_BASE"; do
        pyldapsearch ludus.domain/domainadmin:password "(objectGUID=*)" -base-dn "$dn"  -output "pyldapsearch.$dn.log" -ldaps
done
```

Combined all results into one:
```
$ cat pyldapsearch*.log > combined.log
```

Sorted the objects in the output by their respective `distinguishedName` using the following script:
```
import sys
import re

def read_objects(filename):
    with open(filename, 'r', encoding='utf-8') as f:
        lines = f.readlines()

    separator = None
    objects = []
    current_object = []

    for line in lines:
        if re.match(r'^\s*[-]{2,}\s*$', line):
            if separator is None:
                separator = line.rstrip('\n')  # capture the first separator
            if current_object:
                objects.append("".join(current_object).strip())
                current_object = []
        else:
            current_object.append(line)

    if current_object:
        objects.append("".join(current_object).strip())

    return separator, objects

def get_distinguished_name(object):
    match = re.search(r'^distinguishedName:\s*(.+)', object, re.MULTILINE)
    return match.group(1) if match else ""

def main():
    if len(sys.argv) != 2:
        print("Usage: python normalize.py <filename>")
        sys.exit(1)

    filename = sys.argv[1]
    separator, objects = read_objects(filename)

    sorted_objects = sorted(objects, key=get_distinguished_name)

    for object in sorted_objects:
        print(separator)
        print(object)

if __name__ == "__main__":
    main()
```

Like this:
```
$ python3 normalize.py combined.log > pyldapsearch.log
```

Converted the AD snapshot to LDIF:
```
$ ADExplorerSnapshot.py -m LDIF ludus.dat
[*] Server: DC01.ludus.domain
[*] Time of snapshot: 2025-04-24T09:11:48
[*] Mapping offset: 0x2a127a
[*] Object count: 3742
[+] Parsing properties: 1499
[+] Parsing classes: 269
[+] Parsing object offsets: 3742
[+] Collecting data: dumped 3742 objects
[+] Output written to DC01.ludus.domain_1745478708_objects.ldif
```

Sorted this output too:
```
$ python3 normalize.py DC01.ludus.domain_1745478708_objects.ldif > adexplorer.log
```

Compared the results:
```
$ diff -u adexplorer.log pyldapsearch.log
```

Filtered for changes present in the LDAP query ouput, but not in the snapshot:
```
$ diff -u adexplorer.log pyldapsearch.log | grep '^\+' -B2 -A2 | less
```

Observed that the differences are mostly due to changes happening between taking the snapshot and performing the LDAP queries.

Extracted all field names which differ in the LDAP results:
```
$ diff -u adexplorer.log pyldapsearch.log | grep -a '^\+' | cut -d: -f1 | sort -u
+accountExpires
+creationTime
+dnsRecord
+dSCorePropagationData
+lastLogon
+lastLogonTimestamp
+lastSetTime
+logonCount
+msDS-HasInstantiatedNCs
+otherWellKnownObjects
+priorSetTime
+pwdLastSet
+rIDAllocationPool
+rIDAvailablePool
+rIDPreviousAllocationPool
+uSNChanged
+wellKnownObjects
+whenChanged
```

Concluded with manual analysis that this mostly expected and should be good enough for further processing with BOFHound.

Parsed the AD explorer originated LDIF output file with BOFHound:
```
$ bofhound -i adexplorer.log -o adexplorer

 _____________________________ __    __    ______    __    __   __   __   _______
|   _   /  /  __   / |   ____/|  |  |  |  /  __  \  |  |  |  | |  \ |  | |       \
|  |_)  | |  |  |  | |  |__   |  |__|  | |  |  |  | |  |  |  | |   \|  | |  .--.  |
|   _  <  |  |  |  | |   __|  |   __   | |  |  |  | |  |  |  | |  . `  | |  |  |  |
|  |_)  | |  `--'  | |  |     |  |  |  | |  `--'  | |  `--'  | |  |\   | |  '--'  |
|______/   \______/  |__|     |__|  |___\_\________\_\________\|__| \___\|_________\

                            << @coffeegist | @Tw1sm >>

[10:48:53] INFO     Parsed 3741 LDAP objects from 1 log files
[10:48:53] INFO     Parsed 0 local group/session objects from 1 log files
[10:48:53] INFO     Sorting parsed objects by type...
[10:48:53] INFO     Parsed 17 Users
[10:48:53] INFO     Parsed 56 Groups
[10:48:53] INFO     Parsed 3 Computers
[10:48:53] INFO     Parsed 1 Domains
[10:48:53] INFO     Parsed 0 Trust Accounts
[10:48:53] INFO     Parsed 2 OUs
[10:48:53] INFO     Parsed 211 Containers
[10:48:53] INFO     Parsed 6 GPOs
[10:48:53] INFO     Parsed 1 Enterprise CAs
[10:48:53] INFO     Parsed 1 AIA CAs
[10:48:53] INFO     Parsed 1 Root CAs
[10:48:53] INFO     Parsed 1 NTAuth Stores
[10:48:53] INFO     Parsed 5 Issuance Policies
[10:48:53] INFO     Parsed 41 Cert Templates
[10:48:53] INFO     Parsed 1768 Schemas
[10:48:53] INFO     Parsed 1 Referrals
[10:48:53] INFO     Parsed 1503 Unknown Objects
[10:48:53] INFO     Parsed 0 Sessions
[10:48:53] INFO     Parsed 0 Privileged Sessions
[10:48:53] INFO     Parsed 0 Registry Sessions
[10:48:53] INFO     Parsed 0 Local Group Memberships
[10:48:53] INFO     Parsed 2340 ACL relationships
[10:48:53] INFO     Created default users
[10:48:53] INFO     Created default groups
[10:48:53] INFO     Resolved group memberships
[10:48:53] INFO     Resolved delegation relationships
[10:48:53] INFO     Resolved OU memberships
[10:48:53] INFO     Linked GPOs to OUs
[10:48:53] INFO     Built CA certificate chains
[10:48:53] INFO     Resolved enabled templates per CA
[10:48:53] INFO     JSON files written to adexplorer
```

Compared to the built-in BloodHound output mode you get valid ADCS, GPO, OU and container objects for free.