### PR TITLE
Fix typo in certipy.lib.security import

### DIFF
--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -15,7 +15,7 @@ from frozendict import frozendict
 from bloodhound.enumeration.outputworker import OutputWorker
 
 from certipy.lib.constants import *
-from certipy.lib.security import ActiveDirectorySecurity, CertifcateSecurity as CertificateSecurity, CASecurity
+from certipy.lib.security import ActiveDirectorySecurity, CertificateSecurity as CertificateSecurity, CASecurity
 from certipy.commands.find import filetime_to_str
 from asn1crypto import x509
 


### PR DESCRIPTION
Fixes a small typo in the import from `certipy.lib.security` from `CertifcateSecurity` to `CertificateSecurity`