### PR TITLE
Migrate `MS_PKI_CERTIFICATE_NAME_FLAG` & `MS_PKI_ENROLLMENT_FLAG` to certipy-ad v5 naming convention

### DIFF
--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -15,7 +15,7 @@ from frozendict import frozendict
 from bloodhound.enumeration.outputworker import OutputWorker
 
 from certipy.lib.constants import *
-from certipy.lib.security import ActiveDirectorySecurity, CertifcateSecurity as CertificateSecurity, CASecurity
+from certipy.lib.security import ActiveDirectorySecurity, CertificateSecurity as CertificateSecurity, CASecurity
 from certipy.commands.find import filetime_to_str
 from asn1crypto import x509
 
@@ -483,10 +483,10 @@ class ADExplorerSnapshot(object):
         renewal_period = filetime_to_str(ADUtils.get_entry_property(entry, 'pKIOverlapPeriod'))
         
         certificate_name_flag = ADUtils.get_entry_property(entry, 'msPKI-Certificate-Name-Flag', 0)
-        certificate_name_flag = MS_PKI_CERTIFICATE_NAME_FLAG(int(certificate_name_flag))
+        certificate_name_flag = CertificateNameFlag(int(certificate_name_flag))
 
         enrollment_flag = ADUtils.get_entry_property(entry, 'msPKI-Enrollment-Flag', 0)
-        enrollment_flag = MS_PKI_ENROLLMENT_FLAG(int(enrollment_flag))
+        enrollment_flag = EnrollmentFlag(int(enrollment_flag))
 
         authorized_signatures_required = int(ADUtils.get_entry_property(entry, 'msPKI-RA-Signature', 0))
 
@@ -530,12 +530,12 @@ class ADExplorerSnapshot(object):
         enrollee_supplies_subject = any(
             flag in certificate_name_flag
             for flag in [
-                MS_PKI_CERTIFICATE_NAME_FLAG.ENROLLEE_SUPPLIES_SUBJECT,
+                CertificateNameFlag.ENROLLEE_SUPPLIES_SUBJECT,
             ]
         )
 
         requires_manager_approval = (
-            MS_PKI_ENROLLMENT_FLAG.PEND_ALL_REQUESTS in enrollment_flag
+            EnrollmentFlag.PEND_ALL_REQUESTS in enrollment_flag
         )
 
         security = CertificateSecurity(ADUtils.get_entry_property(entry, "nTSecurityDescriptor", raw=True))

--- a/adexpsnapshot/__init__.py
+++ b/adexpsnapshot/__init__.py
@@ -15,7 +15,7 @@ from frozendict import frozendict
 from bloodhound.enumeration.outputworker import OutputWorker
 
 from certipy.lib.constants import *
-from certipy.lib.security import ActiveDirectorySecurity, CertificateSecurity as CertificateSecurity, CASecurity
+from certipy.lib.security import ActiveDirectorySecurity, CertifcateSecurity as CertificateSecurity, CASecurity
 from certipy.commands.find import filetime_to_str
 from asn1crypto import x509
 


### PR DESCRIPTION
Recently ran into some troubles because a few constants weren't defined.

After a bit of searching it looks like certipy-ad has renamed some of their classes. In particular:

- `MS_PKI_CERTIFICATE_NAME_FLAG` is now `CertificateNameFlag`
- `MS_PKI_ENROLLMENT_FLAG` is now `EnrollmentFlag`