### PR TITLE
Add Windows LAPS v2 support for haslaps detection and ACL parsing to BloodHound mode

### DIFF
--- a/adexpsnapshot/ouput/bloodhound.py
+++ b/adexpsnapshot/ouput/bloodhound.py
@@ -206,7 +206,11 @@ class BloodHoundOutput:
         props['enabled'] = ADUtils.get_entry_property(entry, 'userAccountControl', default=0) & 2 == 0
         props['trustedtoauth'] = ADUtils.get_entry_property(entry, 'userAccountControl', default=0) & 0x01000000 == 0x01000000
         props['samaccountname'] = ADUtils.get_entry_property(entry, 'sAMAccountName')
-        props['haslaps'] = ADUtils.get_entry_property(entry, 'ms-mcs-admpwdexpirationtime', 0) != 0
+        props['haslaps'] = (
+            ADUtils.get_entry_property(entry, 'ms-mcs-admpwdexpirationtime', 0) != 0
+            or
+            ADUtils.get_entry_property(entry, 'msLAPS-PasswordExpirationTime', 0) != 0
+        )
         props['lastlogon'] = ADUtils.win_timestamp_to_unix(ADUtils.get_entry_property(entry, 'lastlogon', default=-1, raw=True))
         props['lastlogontimestamp'] = ADUtils.win_timestamp_to_unix(ADUtils.get_entry_property(entry, 'lastlogontimestamp', default=-1, raw=True))
         if props['lastlogontimestamp'] == 0:
@@ -537,7 +541,11 @@ class BloodHoundOutput:
         return frozenset(aces)
 
     def parse_acl(self, entry, entrytype, acl):
-        parselaps = entrytype == 'computer' and entry['Properties']['haslaps'] and "ms-mcs-admpwd" in self.objecttype_guid_map
+        parselaps = entrytype == 'computer' and entry['Properties']['haslaps'] and (
+            "ms-mcs-admpwd" in self.objecttype_guid_map or
+            "ms-laps-password" in self.objecttype_guid_map or
+            "ms-laps-encryptedpassword" in self.objecttype_guid_map
+        )
         aces = self._parse_acl_cached(parselaps, entrytype, acl)
         self.cacheInfo = self._parse_acl_cached.cache_info()
         return aces


### PR DESCRIPTION
@c3c
Hello, thank you for the great project. 
 
## Summary                                                                        
   
  - Add detection of Windows LAPS v2 (msLAPS-PasswordExpirationTime) in addition 
  to legacy LAPS (ms-mcs-admpwdexpirationtime) for the haslaps computer property
  - Extend ACL parsing to recognize Windows LAPS v2 schema attributes            
  (ms-laps-password, ms-laps-encryptedpassword) alongside the legacy             
  ms-mcs-admpwd GUID
                                                                                 
 ##  Background                                                      

  Windows LAPS v2 (introduced in Windows Server 2019+/April 2023 update) uses new
   schema attributes that differ from the legacy Microsoft LAPS. Snapshots taken
  from environments using Windows LAPS v2 were not being correctly identified as 
  LAPS-enabled, and related ACL entries were being skipped during BloodHound
  output generation.

## Changes

  - adexpsnapshot/output/bloodhound.py:209 — haslaps now returns True if either the legacy or v2      
  expiration time attribute is present
  - adexpsnapshot/output/bloodhound.py:544 — parselaps condition now checks for any of the three      
  LAPS-related object type GUIDs  